### PR TITLE
Add manual consumer group creation to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,6 +27,12 @@ Create the sample topic, by default the topic will have 32 partitions:
 $ heroku kafka:topics:create messages
 ```
 
+Create the sample consumer group if not on a dedicated plan:
+
+```
+$ heroku kafka:consumer-groups:create heroku-kafka-demo-go
+```
+
 Deploy to Heroku and open the app:
 
 ```


### PR DESCRIPTION
Hey Heroku(ers)!

Thanks for adding all of the `KAFKA_PREFIX` support recently.  Worked like a charm!  Only other thing was I needed to create a consumer group manually.  Figured I'd document it :)