### PR TITLE
Set producer to wait for acks from all brokers in ISR

### DIFF
--- a/main.go
+++ b/main.go
@@ -252,6 +252,7 @@ func (ac *AppConfig) createKafkaProducer(brokers []string, tc *tls.Config) saram
 	config.Net.TLS.Config = tc
 	config.Net.TLS.Enable = true
 	config.Producer.Return.Errors = true
+	config.Producer.RequiredAcks = sarama.WaitForAll // Default is WaitForLocal
 	config.ClientID = ac.Kafka.ConsumerGroup
 
 	err := config.Validate()


### PR DESCRIPTION
By default, the producer only waits for an ack from the local broker (`WaitForLocal`). 

This PR sets the producer to require acks from all brokers in the ISR (`WaitForAll`).