### PR TITLE
Simplify connecting to Kafka by using sarama-heroku

### DIFF
--- a/vendor/github.com/deadmanssnitch/sarama-heroku/CODE_OF_CONDUCT.md
+++ b/vendor/github.com/deadmanssnitch/sarama-heroku/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at oss@collectiveidea.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct/
+
+[homepage]: https://www.contributor-covenant.org

--- a/vendor/github.com/deadmanssnitch/sarama-heroku/LICENSE
+++ b/vendor/github.com/deadmanssnitch/sarama-heroku/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Collective Idea
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/deadmanssnitch/sarama-heroku/README.md
+++ b/vendor/github.com/deadmanssnitch/sarama-heroku/README.md
@@ -1,0 +1,124 @@
+# Sarama Heroku
+
+[![GoDoc](https://godoc.org/github.com/deadmanssnitch/sarama-heroku?status.svg)](http://godoc.org/github.com/deadmanssnitch/sarama-heroku)
+
+## Overview
+
+sarama-heroku is a Go library that makes it easy to connect to [Heroku
+Kafka](https://www.heroku.com/kafka).  We handle all the certificate management
+and configuration so that you can start up your Kafka consumers and producers
+with minimal effort.
+
+## Installation
+
+```console
+go get -u github.com/deadmanssnitch/sarama-heroku
+```
+
+### Heroku
+
+Make sure you have the Heroku CLI plugin installed:
+```console
+heroku plugins:install heroku-kafka
+```
+
+Next, you'll need to provision a new Kafka install or attach an existing one to
+your app. To provision run:
+```console
+heroku addons:create heroku-kafka:basic-0 -a [app]
+heroku kafka:wait -a [app]
+```
+
+## Consumers
+
+Now you are ready to start using the library. From here there are two options.
+You can either create your own configuration or it is possible to pass in a nil
+config to create a cluster consumer based on the defaults configurations.
+
+Create a cluster consumer using a custom config like the following:
+
+```go
+config := cluster.NewConfig()
+config.Group.PartitionStrategy = cluster.StrategyRoundRobin
+config.Group.Return.Notifications = true
+config.ClientID = "app-name." + os.Getenv("DYNO")
+config.Consumer.Return.Errors = true
+
+consumer, err := heroku.NewClusterConsumer("group-id", []string{"topic"}, config)
+```
+
+:heavy_exclamation_mark: Multi-tenant plans require creating the consumer
+groups before you can use them.
+```console
+heroku kafka:consumer-groups:create 'group-id' -a [app]
+```
+
+For an example on using sarama-cluster
+[check the sarama-cluster repo](https://github.com/bsm/sarama-cluster) or
+[see the documentation](https://godoc.org/github.com/bsm/sarama-cluster).
+
+## Producers
+
+There are multiple options for producers. Similar to consumers, you can specify
+your own config or pass in a nil config for defaults. Furthermore, a producer
+can be either Sync or Async. Read up on the differences
+[here](https://godoc.org/github.com/Shopify/sarama).
+
+Creating an async producer from a custom config:
+
+```go
+config := sarama.NewConfig()
+config.Producer.Return.Errors = true
+config.Producer.RequiredAcks = sarama.WaitForAll
+
+producer, err := heroku.NewAsyncProducer(config)
+```
+
+:heavy_exclamation_mark: Multi-tenant plans require adding the KAFKA_PREFIX
+when sending messages. You should use heroku.AppendPrefixTo("topic") to ensure
+it's set.
+
+```go
+producer <- &sarama.ProducerMessage{
+  Topic: heroku.AppendPrefixTo("events"),
+  Key:   sarama.StringEncoder(key),
+  Value: []byte("Message"),
+}
+```
+For more information about how to set up a config see the
+[sarama documentation](http://godoc.org/github.com/Shopify/sarama#Config).
+
+## Environment
+
+Sarama Heroku depends on the following environment variables that are set by Heroku Kafka
+
+  - KAFKA\_CLIENT\_CERT
+  - KAFKA\_CLIENT\_CERT\_KEY
+  - KAFKA\_TRUSTED\_CERT
+  - KAFKA\_PREFIX (only multi-tenant plans)
+  - KAFKA\_URL
+
+## Contributing
+Thank you so much for your interest in contributing to this repository. We appreciate you and the work you're doing on this SO much.
+
+**How often are we checking this repository for issues or PRs:**
+If you post an issue or PR and do not hear back right away, do not worry! We aren't ignoring you. Expect to hear back within a couple of weeks. Typically, we check this repository once a month on the last Friday to review PRs, issues, and other maintenance duties.
+
+**Submitting an Issue**
+
+Before you contribute, please take a look at this [helpful article](https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution) and follow the guidelines. It is important to supply enough context and information so that we can get to it as quickly as possible.
+
+* Please include a screenshot
+* Please include exact steps to replicate the bug or issue with as much information as possible
+* Please include any "hunches" you may have about what the issue might be
+
+**Submitting a PR:**
+
+* Please [fork](https://help.github.com/articles/creating-a-pull-request-from-a-fork/) the respository, put your code change on a new branch and then create a pull request against master in the main repository.
+* In the PR description, please include the following:
+	- A link to the issue is there is one
+	- A screenshot, gif, or detailed description of before and after functionality
+	- Any applicable tests, if warranted
+	- Instructions on how to QA if applicable
+
+Thank you for contributing to open source software. Your work is helping us all make better software. Happy coding!

--- a/vendor/github.com/deadmanssnitch/sarama-heroku/heroku.go
+++ b/vendor/github.com/deadmanssnitch/sarama-heroku/heroku.go
@@ -1,0 +1,229 @@
+package heroku
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/Shopify/sarama"
+	cluster "github.com/bsm/sarama-cluster"
+)
+
+// NewClusterConsumer creates a github.com/bsm/sarama-cluster.Consumer based on
+// Heroku Kafka standard environment configs. Giving nil for cfg will create a
+// generic config.
+func NewClusterConsumer(groupID string, topics []string, cfg *cluster.Config) (*cluster.Consumer, error) {
+	err := prepareClusterConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Consumer groups require the Kafka prefix
+	groupID = AppendPrefixTo(groupID)
+
+	// Ensure all topics have the Kafka prefix applied
+	for idx, topic := range topics {
+		topics[idx] = AppendPrefixTo(topic)
+	}
+
+	brokers, err := Brokers()
+	if err != nil {
+		return nil, err
+	}
+
+	return cluster.NewConsumer(brokers, groupID, topics, cfg)
+}
+
+// NewConsumer creates a github.com/Shopify/sarama.Consumer configured from the
+// standard Heroku Kafka environment.
+func NewConsumer(cfg *sarama.Config) (sarama.Consumer, error) {
+	if err := prepareConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	brokers, err := Brokers()
+	if err != nil {
+		return nil, err
+	}
+	consumer, err := sarama.NewConsumer(brokers, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return consumer, nil
+}
+
+// NewAsyncProducer creates a github.com/Shopify/sarama.AsyncProducer
+// configured from the standard Heroku Kafka environment. When publishing
+// messages to Multitenant Kafka all topics need to start with KAFKA_PREFIX
+// which is best added using AppendPrefixTo.
+func NewAsyncProducer(cfg *sarama.Config) (sarama.AsyncProducer, error) {
+	if err := prepareConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	brokers, err := Brokers()
+	if err != nil {
+		return nil, err
+	}
+
+	return sarama.NewAsyncProducer(brokers, cfg)
+}
+
+// NewSyncProducer creates a github.com/Shopify/sarama.SyncProducer configured
+// from the standard Heroku Kafka environment. When publishing messages to
+// Multitenant Kafka all topics need to start with KAFKA_PREFIX which is best
+// added using AppendPrefixTo.
+func NewSyncProducer(cfg *sarama.Config) (sarama.SyncProducer, error) {
+	if err := prepareConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	brokers, err := Brokers()
+	if err != nil {
+		return nil, err
+	}
+
+	return sarama.NewSyncProducer(brokers, cfg)
+}
+
+// AppendPrefixTo adds the env variable KAFKA_PREFIX to the given string if
+// necessary. Heroku requires prefixing topics and consumer group names with
+// the prefix on multi-tenant plans. It is safe to use on dedicated clusters if
+// KAFKA_PREFIX is not set.
+func AppendPrefixTo(name string) string {
+	prefix := os.Getenv("KAFKA_PREFIX")
+
+	if strings.HasPrefix(name, prefix) {
+		return name
+	}
+
+	return prefix + name
+}
+
+// Create the TLS context, using the key and certificates provided.
+func TLSConfig() (*tls.Config, error) {
+	trustedCert := os.Getenv("KAFKA_TRUSTED_CERT")
+	if trustedCert == "" {
+		return nil, errors.New("KAFKA_TRUSTED_CERT is not set in environment")
+	}
+
+	clientCertKey := os.Getenv("KAFKA_CLIENT_CERT_KEY")
+	if clientCertKey == "" {
+		return nil, errors.New("KAFKA_CLIENT_CERT_KEY is not set in environment")
+	}
+
+	clientCert := os.Getenv("KAFKA_CLIENT_CERT")
+	if clientCert == "" {
+		return nil, errors.New("KAFKA_CLIENT_CERT is not set in environment")
+	}
+
+	roots := x509.NewCertPool()
+	ok := roots.AppendCertsFromPEM([]byte(trustedCert))
+	if !ok {
+		return nil, errors.New("Invalid Root Cert. Please check your Heroku environment.")
+	}
+
+	// Create a certificate bundle for the TLS Config
+	cert, err := tls.X509KeyPair([]byte(clientCert), []byte(clientCertKey))
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      roots,
+
+		// Disable normal certificate verification because Heroku's certificates do
+		// not match their hostnames.
+		InsecureSkipVerify: true,
+
+		// VerifyPeerCertificate will check that the certificate was signed by the
+		// trusted certificate Heroku sets in the environment. The second parameter
+		// will always be empty since InsecureSkipVerify is true.
+		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			opts := x509.VerifyOptions{Roots: roots}
+
+			// Heroku is only giving one rawCert as of 2017-09-19. If that changes
+			// then this code may not longer be valid.
+			for _, raw := range rawCerts {
+				cert, err := x509.ParseCertificate(raw)
+				if err != nil {
+					return err
+				}
+
+				// If any of the raw certificates fail verification then we fail the
+				// entire process.
+				_, err = cert.Verify(opts)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	}, nil
+}
+
+// Brokers returns a list of host:port addresses for the Kafka brokers set in
+// KAFKA_URL.
+func Brokers() ([]string, error) {
+	URL := os.Getenv("KAFKA_URL")
+	if URL == "" {
+		return nil, errors.New("KAFKA_URL is not set in environment")
+	}
+
+	urls := strings.Split(URL, ",")
+	addrs := make([]string, len(urls))
+	for i, v := range urls {
+		u, err := url.Parse(v)
+		if err != nil {
+			return nil, err
+		}
+
+		// Validate the kafka+ssl url format. This simplifies our handling by
+		// requiring a strict format that Heroku should provide for us.
+		if u.Scheme != "kafka+ssl" {
+			return nil, errors.New("kafka urls should start with kafka+ssl://")
+		}
+
+		addrs[i] = u.Host
+	}
+
+	return addrs, nil
+}
+
+func prepareClusterConfig(cfg *cluster.Config) error {
+	if cfg == nil {
+		cfg = cluster.NewConfig()
+	}
+
+	tc, err := TLSConfig()
+	if err != nil {
+		return err
+	}
+
+	cfg.Net.TLS.Config = tc
+	cfg.Net.TLS.Enable = true
+
+	return nil
+}
+
+func prepareConfig(cfg *sarama.Config) error {
+	if cfg == nil {
+		cfg = sarama.NewConfig()
+	}
+
+	tc, err := TLSConfig()
+	if err != nil {
+		return err
+	}
+
+	cfg.Net.TLS.Config = tc
+	cfg.Net.TLS.Enable = true
+
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,10 +1,12 @@
 {
 	"comment": "",
+	"heroku": {
+		"goVersion": "go1.8",
+		"install": [
+			"."
+		]
+	},
 	"ignore": "test",
-    "heroku": {
-        "goVersion": "go1.8",
-        "install": ["."]
-    },
 	"package": [
 		{
 			"checksumSHA1": "gwnUhIsatKCPs5W7Rx5LfpF2RZA=",
@@ -27,6 +29,12 @@
 			"checksumSHA1": "a2yC46a1qsJomgY6rb+FkTFiqmE=",
 			"path": "github.com/davecgh/go-spew/spew/testdata",
 			"revision": "1aaf839fb07e099361e445273993ccd9adc21b07"
+		},
+		{
+			"checksumSHA1": "YXaLK72BNtC1l/maPafUj2faoTQ=",
+			"path": "github.com/deadmanssnitch/sarama-heroku",
+			"revision": "9838a84ef252440b7b904941846eff9785da4ca8",
+			"revisionTime": "2017-09-20T13:49:12Z"
 		},
 		{
 			"checksumSHA1": "y2Kh4iPlgCPXSGTCcFpzePYdzzg=",


### PR DESCRIPTION
This change has two main advantages: it reduces the amount of code
needed to connect to Heroku Kafka and it improves security around
certificate verification.

The demo code includes a lot of boilerplate for verifying certificates
that would likely be copy and pasted into apps using this code as a
starting point. It's easy to imagine someone copying the code but
leaving out the verification step because they don't understand it.

Additionally, the current method is fundamentally flawed in that it only
verifies certificates on boot. The TLSConfig created by sarama-heroku
includes a custom certificate verifier that will validate the server's
certificate against the trusted cert on each connect. This would allow
validating any new servers that appear in the metadata after launch
without a restart.

Finally, this makes integrating with Heroku Kafka a lot easier and
consolidates the tricky to understand certificate process into a
reusable component. I was able to remove 125 lines from main.go,
allowing it to be more focused on using Kafka and not connecting.