### PR TITLE
adds missing step to create the consumer group

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,6 +28,8 @@ $ heroku kafka:topics:create messages
 
 Create the consumer group:
 
+**Note:** This assumes that you are using a `basic-0` as specified above. This step is not necessary for standard, private, or shield kafka plans.
+
 ```
 $ heroku kafka:consumer-groups:create heroku-kafka-demo-go
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -26,6 +26,12 @@ Create the sample topic. By default, the topic will have 8 partitions:
 $ heroku kafka:topics:create messages
 ```
 
+Create the consumer group:
+
+```
+$ heroku kafka:consumer-groups:create heroku-kafka-demo-go
+```
+
 Deploy to Heroku and open the app:
 
 ```


### PR DESCRIPTION
Adds a missing step to the readme. The consumer group must be created before starting the the demo app.